### PR TITLE
Stream-02709 : Feature: Filter out duplicates from integer list

### DIFF
--- a/src/com/jg/coding/RemoveDuplicateDemo.java
+++ b/src/com/jg/coding/RemoveDuplicateDemo.java
@@ -1,0 +1,15 @@
+package com.jg.coding;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RemoveDuplicateDemo {
+
+	public static void main(String[] args) {
+		List<Integer> listOfIntegers = Arrays.asList(2,5,6,7,88,88,5,2,3,9);
+		List<Integer> uniqueInteger = listOfIntegers.stream().distinct().collect(Collectors.toList());
+		System.out.println(uniqueInteger);
+	}
+
+}


### PR DESCRIPTION
### Summary / Motivation
Currently, the input list may contain duplicate integer values. To ensure we operate on a list of unique values, this PR adds logic to filter out duplicates.

### What Changed
- In `RemoveDuplicateDemo.main()`, used `stream().distinct()` to derive a list with unique integers.
- Collected the result with `Collectors.toList()` and printed it.

### How It Works
The `distinct()` method in the Stream API returns a new stream that has no duplicate elements (based on `equals()`), preserving encounter order.  
If the input list is ordered, the first occurrence is kept.  
This is a straightforward and readable approach using the Java 8 Streams API.

### Edge Cases & Considerations
- If the input list is empty or has no duplicates, behavior remains correct.
- If elements are custom objects (not primitives or simple wrappers), their `equals()` (and `hashCode()`) should be implemented so that duplicates are recognized properly.
- For very large lists, the memory overhead of streaming and collecting should be considered.
- Using `parallelStream()` with `distinct()` might introduce performance or ordering issues — not used here.

### Testing / Verification
Test with:
- `[2,5,6,7,88,88,5,2,3,9]` → expected output `[2,5,6,7,88,3,9]` (duplicates removed, order preserved)
- An empty list → `[]`
- A list with no duplicates → same list
- A list with all items duplicate → one element list

Unit tests can be added in a separate test class to cover these cases.

### References
- Java Stream API: `distinct()` documentation  
- (Optional) Link to issue / ticket: `#1234`
@YuvrajSingh715 
@abhisheksingh1987 